### PR TITLE
:gun:  Oneliner > Envoi en masse avec un `csv` d'input et `awk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,40 @@ cat secrets.txt\
     | mobitag pipe --to $MOBILIS_DEST
 ```
 
+## 📤 Envoi de `sms` en masse avec `awk`
+
+### A propos de `awk`
+
+Comment développer un `cli` sans proposer une intégration avec le légendaire `awk` ?
+Voyons donc comment envoyer des sms en masse en combinant `mobitag` et `awk` 🚀
+
+🎤 D'abord, bien comprendre la phitlosophie de `awk` : [7' interview of Brian Kernighan for the legacy.](https://www.youtube.com/watch?v=W5kr7X7EG4o)
+
+### Envoyer un `csv`
+
+Supposons que l'on ait le `csv` suivant (par exemple en sortie d'un traitement précédent) : 
+
+```
+dest,msg,from
+NUMERO_1,"NERD ALERT : Demo automatisation csv avec awk - exemple 1",""
+NUMERO_2,"NERD ALERT : Demo automatisation csv avec awk - exemple 2",""
+```
+Alors on peut générer un "dry run" (ie. génération de commandes sans les éxécuter) : 
+
+```sh
+# Génération des commandes : 
+awk -F',' 'NR > 1 && $1 != "" {print "mobitag send --to " $1 " --message " $2 " --from " $3 }' mobitags.csv
+```
+
+Puis exécuter :
+
+
+```
+awk -F',' 'NR > 1 && $1 != "" {print "mobitag send --to " $1 " --message " $2 " --from " $3 }' mobitags.csv |\
+    bash
+```
+
+
 # 🧑‍🤝‍🧑 Equipe
 
 Ce projet d'innovation frugale n'aurait pas vu le jour sans une équipe, par ordre d'entré sur le projet :


### PR DESCRIPTION
# :grey_question: A propos

Nous avons das le pipe les issues suivantes en lien avec l'envoi de sms en masse (par exemple avec un csv d'input)  et les "one liners" :  

- https://github.com/opt-nc/mobitag/issues/10
- https://github.com/opt-nc/mobitag/issues/39

:point_right: Le but de cette PR est de documenter comment réaliser cela juste avec `mobitag` et [`awk`](https://www.youtube.com/watch?v=W5kr7X7EG4o)

# :dart: Actions

- [x] Regarder [AWK Is Still Very Useful | Brian Kernighan and Lex Fridman](https://www.youtube.com/watch?v=W5kr7X7EG4o)
- [x] Regarder  [Coffee with Brian Kernighan - Computerphile](https://youtu.be/GNyQxXw_oMQ?si=uFcizHb6XhiVtYAQ&t=24)
- [x] Jouer la demo en local avec un `csv` avec son propre numéro **et dropper un screenshot marrant**
- [x] Merger
- [ ] Faire la comm' sur les réseaux sociaux  lors de la prochaine release

# :microphone:  Ressources

- [AWK Is Still Very Useful | Brian Kernighan and Lex Fridman](https://www.youtube.com/watch?v=W5kr7X7EG4o)
- [Coffee with Brian Kernighan - Computerphile](https://youtu.be/GNyQxXw_oMQ?si=uFcizHb6XhiVtYAQ&t=24)

![image](https://github.com/user-attachments/assets/e2b59228-0064-4cd2-990c-439e4548196b)
