### PR TITLE
:bug:  fix: La commande `dryRun` ne doit plus apparaître dans la doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,22 +78,10 @@ Afficher l'aide :
 mobitag
 ```
 
-Tester l'environnement afin de vérifier la présence de la clé API : 
-
-```sh
-mobitag dryRun
-```
-
 Envoyer un `mobit@g` : 
 
 ```sh
-mobitag send --to xxxxxx --message "Hello World : a mobit@g from Go(lang) XD"
-```
-
-En indiquant également le numéro de l'expéditeur
-
-```sh
-mobitag send --to xxxxxx --message "Hello World : a mobit@g from Go(lang) XD" --from yyyyyy
+mobitag help send
 ```
 
 # 🗑️ Désinstaller


### PR DESCRIPTION
# :grey_question: A propos

Hier, lors d'une install party, l'utilisateur final, au lieu d'utiliser l'aide embarquée dans le `cli` a utilisé la doc présente dans le `README` : il a donc utilisé la commande `dryRun`... qui n'existe plus dans le cli depuis : 

- https://github.com/opt-nc/mobitag/issues/123

<img width="816" height="330" alt="image" src="https://github.com/user-attachments/assets/5fdf60d9-6fc5-4027-99ed-d56c2a05341b" />

# :dart:   Actions

- [ ] Merger cette PR fixe cela en redirigeant vers la commande dédiée, plus clean, plus riche et qui se maintient dynamiquement
- [ ] Releaser une nouvelle version afin que la doc soit juste