### PR TITLE
fix: Enlever le from tant que from ne fonctionne pas

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,8 +14,8 @@ var rootCmd = &cobra.Command{
 	Use:   "mobitag",
 	Short: "Envoyer des sms avec Mobitag",
 	Long:  `CLI permettant d'envoyer des sms gratuits en contactant l'API de Mobitag. Afin de vérifier la configuration, utilisez la commande 'mobitag check-apikey'.`,
-	Example: `mobitag send --to <destinataire> --message <message> --from <expéditeur>
-whoami | mobitag pipe --to 123456 --from 654321`,
+	Example: `mobitag send --to <destinataire> --message <message>
+whoami | mobitag pipe --to 123456`,
 
 	// Uncomment the following line if your bare application
 	// has an action associated with it:


### PR DESCRIPTION
# :grey_question: A propos

cf
- #150

La PR que j'ai fait le we dernier a sauté, le from est toujours là : 

<img width="1369" height="749" alt="image" src="https://github.com/user-attachments/assets/10cb56bf-a2e8-4010-9820-dcb7136ac03d" />

# :dart: Actions

- Merger
- Releaser